### PR TITLE
Typo fixed in dropdownmenu delegate expandingChanged delegate .h and …

### DIFF
--- a/IGLDropDownMenu/IGLDropDownMenu.h
+++ b/IGLDropDownMenu/IGLDropDownMenu.h
@@ -37,8 +37,8 @@ typedef NS_ENUM(NSUInteger, IGLDropDownMenuDirection) {
 
 @optional
 - (void)dropDownMenu:(IGLDropDownMenu*)dropDownMenu selectedItemAtIndex:(NSInteger)index;
-- (void)dropDownMenu:(IGLDropDownMenu *)dropDownMenu expandingChanged:(BOOL)isExpending;
-- (void)dropDownMenu:(IGLDropDownMenu *)dropDownMenu expandingChangedWithAnimationCompledted:(BOOL)isExpending;
+- (void)dropDownMenu:(IGLDropDownMenu *)dropDownMenu expandingChanged:(BOOL)isExpanding;
+- (void)dropDownMenu:(IGLDropDownMenu *)dropDownMenu expandingChangedWithAnimationCompledted:(BOOL)isExpanding;
 
 @end
 

--- a/IGLDropDownMenuDemo/IGLDemoViewController.m
+++ b/IGLDropDownMenuDemo/IGLDemoViewController.m
@@ -312,13 +312,13 @@
     
 }
 
-- (void)dropDownMenu:(IGLDropDownMenu *)dropDownMenu expandingChanged:(BOOL)isExpending
+- (void)dropDownMenu:(IGLDropDownMenu *)dropDownMenu expandingChanged:(BOOL)isExpanding
 {
-    NSLog(@"Expending changed to: %@", isExpending? @"expand" : @"fold");
+    NSLog(@"Expending changed to: %@", isExpanding? @"expand" : @"fold");
 
 }
 
-- (void)dropDownMenu:(IGLDropDownMenu *)dropDownMenu expandingChangedWithAnimationCompledted:(BOOL)isExpending
+- (void)dropDownMenu:(IGLDropDownMenu *)dropDownMenu expandingChangedWithAnimationCompledted:(BOOL)isExpanding
 {
     NSLog(@"IGLDropDownMenu size: %@", NSStringFromCGSize(dropDownMenu.bounds.size));
 }

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ If you use customView, the customView will auto set `userInteractionEnabled = NO
 
 ####*For `IGLDropDownMenu`*
 - `- (void)dropDownMenu:(IGLDropDownMenu*)dropDownMenu selectedItemAtIndex:(NSInteger)index;`
-- `- (void)dropDownMenu:(IGLDropDownMenu *)dropDownMenu expandingChanged:(BOOL)isExpending;`
+- `- (void)dropDownMenu:(IGLDropDownMenu *)dropDownMenu expandingChanged:(BOOL)isExpanding;`
 
 ## Requirements
 


### PR DESCRIPTION
….m, and in DemoViewController

Replaced `, expandingChanged isExpending: Bool)` with `, expandingChanged isExpanding: Bool)` throughout.